### PR TITLE
Fix Docker container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The image is available at https://hub.docker.com/repository/docker/yeya24/tidb-p
 ### Start container
 
 ``` bash
-docker run -d -p 4000:4000 -p 2379:2379 hooopo/tiup-playground:v5.2.0
+docker run -d -p 4000:4000 -p 2379:2379 hooopo/tidb-playground:v5.2.0
 ```
 
 After few seconds we can check the logs of the container to make sure our TiDB cluster is up and running.


### PR DESCRIPTION
* Follow the step as is

```
$ docker run -d -p 4000:4000 -p 2379:2379 hooopo/tiup-playground:v5.2.0
Unable to find image 'hooopo/tiup-playground:v5.2.0' locally
docker: Error response from daemon: pull access denied for hooopo/tiup-playground, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```

* Follow the step as this pull request explains

```
$ docker run -d -p 4000:4000 -p 2379:2379 hooopo/tidb-playground:v5.2.0
1140ef82354db564c2c0bd2d31e20a55d9894f98f50d8cff4754457817a140b7
```