### PR TITLE
Build tidb-playground v5.3.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TIDB_VERSION_SLICE=('v5.1.1' 'v5.1.0' 'v5.0.3' 'v5.2.0')
+TIDB_VERSION_SLICE=('v5.1.1' 'v5.1.0' 'v5.0.3' 'v5.2.0' 'v5.3.0')
 
 for version in "${TIDB_VERSION_SLICE[@]}"
 do


### PR DESCRIPTION
This pull request enables users to build `tidb-playground` v5.3.0.

https://docs.pingcap.com/tidb/stable/release-5.3.0

Here are image names built by this updated script.
```
% ./build.sh
... snip ...
% docker images
REPOSITORY               TAG       IMAGE ID       CREATED         SIZE
hooopo/tidb-playground   v5.0.3    136175b78800   2 minutes ago   522MB
hooopo/tidb-playground   v5.1.0    136175b78800   2 minutes ago   522MB
hooopo/tidb-playground   v5.1.1    136175b78800   2 minutes ago   522MB
hooopo/tidb-playground   v5.2.0    136175b78800   2 minutes ago   522MB
hooopo/tidb-playground   v5.3.0    136175b78800   2 minutes ago   522MB
%
```
